### PR TITLE
ensuring event handlers only used once

### DIFF
--- a/test/fixtures/downloads/index.html
+++ b/test/fixtures/downloads/index.html
@@ -10,6 +10,9 @@
     <div>
       <a href='/download/20mib.txt' id='dl2'>download 20mib txt file</a>
     </div>
+    <div>
+      <a href='/download/200kib.txt' id='dl3'>download 200kib txt file</a>
+    </div>
   </body>
   <script>
     


### PR DESCRIPTION
Also makes sure the parent request is reset.  Fixes #6.
